### PR TITLE
CORE-1833: user summary handler fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+all: subscriptions dev-test/dev-test
+
+SOURCES = $(wildcard *.go) $(wildcard */*.go)
+
+subscriptions: ${SOURCES}
+	go build --buildvcs=false .
+
+dev-test/dev-test: ${SOURCES}
+	go build --trimpath -o dev-test ./dev-test
+
+clean:
+	rm -rf subscriptions dev-test/dev-test
+
+.PHONY: all clean dev-test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-all: subscriptions dev-test/dev-test
+all: subscriptions
+
+test-prog: dev-test/dev-test
 
 SOURCES = $(wildcard *.go) $(wildcard */*.go)
 
@@ -11,4 +13,4 @@ dev-test/dev-test: ${SOURCES}
 clean:
 	rm -rf subscriptions dev-test/dev-test
 
-.PHONY: all clean dev-test
+.PHONY: all clean test-prog

--- a/app/summary.go
+++ b/app/summary.go
@@ -8,16 +8,10 @@ import (
 	"github.com/cyverse-de/subscriptions/db"
 	"github.com/cyverse-de/subscriptions/errors"
 	"github.com/sirupsen/logrus"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func (a *App) GetUserSummary(subject, reply string, request *qms.RequestByUsername) {
-	var (
-		err  error
-		pqds []*qms.QuotaDefault
-		qs   []*qms.Quota
-		us   []*qms.Usage
-	)
+	var err error
 
 	log := log.WithFields(logrus.Fields{"context": "user summary"})
 
@@ -44,88 +38,35 @@ func (a *App) GetUserSummary(subject, reply string, request *qms.RequestByUserna
 
 	d := db.New(a.db)
 
-	log.Debug("before getting the active user plan")
-	userPlan, err := d.GetActiveUserPlan(ctx, username)
+	var userPlan *db.UserPlan
+	tx, err := d.Begin()
 	if err != nil {
 		sendError(ctx, response, err)
 		return
 	}
-	log.Debug("after getting the active user plan")
+	err = tx.Wrap(func() error {
+		log.Debug("before getting the active user plan")
+		userPlan, err = d.GetActiveUserPlan(ctx, username)
+		if err != nil {
+			return err
+		}
+		log.Debug("after getting the active user plan")
 
-	log.Debug("before getting the user plan details")
-	defaults, quotas, usages, err := d.UserPlanDetails(ctx, userPlan)
+		log.Debug("before getting the user plan details")
+		err = d.LoadUserPlanDetails(ctx, userPlan)
+		if err != nil {
+			return err
+		}
+		log.Debug("affter getting the user plan details")
+
+		return nil
+	})
 	if err != nil {
 		sendError(ctx, response, err)
 		return
 	}
-	log.Debug("affter getting the user plan details")
 
-	for _, pqd := range defaults {
-		def := &qms.QuotaDefault{
-			Uuid:       pqd.ID,
-			QuotaValue: float32(pqd.QuotaValue),
-			ResourceType: &qms.ResourceType{
-				Uuid: pqd.ResourceType.ID,
-				Name: pqd.ResourceType.Name,
-				Unit: pqd.ResourceType.Unit,
-			},
-		}
-		pqds = append(pqds, def)
-	}
-
-	for _, quota := range quotas {
-		q := &qms.Quota{
-			Uuid:  quota.ID,
-			Quota: float32(quota.Quota),
-			ResourceType: &qms.ResourceType{
-				Uuid: quota.ResourceType.ID,
-				Name: quota.ResourceType.Name,
-				Unit: quota.ResourceType.Unit,
-			},
-			CreatedBy:      quota.CreatedBy,
-			CreatedAt:      timestamppb.New(quota.CreatedAt),
-			LastModifiedBy: quota.LastModifiedBy,
-			LastModifiedAt: timestamppb.New(quota.LastModifiedAt),
-		}
-		qs = append(qs, q)
-	}
-
-	for _, usage := range usages {
-		u := &qms.Usage{
-			Uuid:       usage.ID,
-			Usage:      usage.Usage,
-			UserPlanId: userPlan.ID,
-			ResourceType: &qms.ResourceType{
-				Uuid: usage.ResourceType.ID,
-				Name: usage.ResourceType.Name,
-				Unit: usage.ResourceType.Unit,
-			},
-			CreatedBy:      usage.CreatedBy,
-			CreatedAt:      timestamppb.New(usage.CreatedAt),
-			LastModifiedBy: usage.LastModifiedBy,
-			LastModifiedAt: timestamppb.New(usage.LastModifiedAt),
-		}
-		us = append(us, u)
-	}
-
-	response.UserPlan = &qms.UserPlan{
-		Uuid:               userPlan.ID,
-		EffectiveStartDate: timestamppb.New(userPlan.EffectiveStartDate),
-		EffectiveEndDate:   timestamppb.New(userPlan.EffectiveEndDate),
-		User: &qms.QMSUser{
-			Uuid:     userPlan.User.ID,
-			Username: userPlan.User.Username,
-		},
-		Plan: &qms.Plan{
-			Uuid:              userPlan.Plan.ID,
-			Name:              userPlan.Plan.Name,
-			Description:       userPlan.Plan.Description,
-			PlanQuotaDefaults: pqds,
-		},
-		Quotas: qs,
-		Usages: us,
-	}
-
+	response.UserPlan = userPlan.ToQMSUserPlan()
 	if err = a.client.Respond(ctx, reply, response); err != nil {
 		log.Error(err)
 	}

--- a/app/summary.go
+++ b/app/summary.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cyverse-de/go-mod/pbinit"
 	"github.com/cyverse-de/p/go/qms"
@@ -10,7 +11,80 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (a *App) GetUserSummary(subject, reply string, request *qms.RequestByUsername) {
+func (a *App) GetUserSummary(ctx context.Context, username string) (*qms.UserPlan, error) {
+	// Set up the log context.
+	log := log.WithFields(
+		logrus.Fields{
+			"context": "user summary",
+			"user":    username,
+		},
+	)
+
+	// Get the user summary.
+	d := db.New(a.db)
+
+	var userPlan *db.UserPlan
+	tx, err := d.Begin()
+	if err != nil {
+		return nil, err
+	}
+	err = tx.Wrap(func() error {
+		log.Debug("before getting the active user plan")
+		userPlan, err = d.GetActiveUserPlan(ctx, username, db.WithTX(tx))
+		if err != nil {
+			log.Errorf("unable to get the active user plan: %s", err)
+			return err
+		}
+		log.Debug("after getting the active user plan")
+
+		if userPlan == nil || userPlan.ID == "" {
+			user, err := d.EnsureUser(ctx, username, db.WithTX(tx))
+			if err != nil {
+				log.Errorf("unable to ensure that the user exists in the database: %s", err)
+				return err
+			}
+
+			plan, err := d.GetPlanByName(ctx, db.DefaultPlanName, db.WithTX(tx))
+			if err != nil {
+				log.Errorf("unable to look up the default plan: %s", err)
+				return err
+			}
+
+			userPlanID, err := d.SetActiveUserPlan(ctx, user.ID, plan.ID, db.WithTX(tx))
+			if err != nil {
+				log.Errorf("unable to subscribe the user to the default plan: %s", err)
+				return err
+			}
+
+			userPlan, err = d.GetUserPlanByID(ctx, userPlanID, db.WithTX(tx))
+			if err != nil {
+				log.Errorf("unable to look up the new user plan: %s", err)
+				return err
+			}
+			if userPlan == nil {
+				err = fmt.Errorf("the newly inserted user plan could not be found")
+				log.Error(err)
+				return err
+			}
+		}
+
+		log.Debug("before getting the user plan details")
+		err = d.LoadUserPlanDetails(ctx, userPlan, db.WithTX(tx))
+		if err != nil {
+			return err
+		}
+		log.Debug("affter getting the user plan details")
+
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return userPlan.ToQMSUserPlan(), nil
+}
+
+func (a *App) GetUserSummaryHandler(subject, reply string, request *qms.RequestByUsername) {
 	var err error
 
 	log := log.WithFields(logrus.Fields{"context": "user summary"})
@@ -36,37 +110,13 @@ func (a *App) GetUserSummary(subject, reply string, request *qms.RequestByUserna
 
 	log = log.WithFields(logrus.Fields{"user": username})
 
-	d := db.New(a.db)
-
-	var userPlan *db.UserPlan
-	tx, err := d.Begin()
-	if err != nil {
-		sendError(ctx, response, err)
-		return
-	}
-	err = tx.Wrap(func() error {
-		log.Debug("before getting the active user plan")
-		userPlan, err = d.GetActiveUserPlan(ctx, username)
-		if err != nil {
-			return err
-		}
-		log.Debug("after getting the active user plan")
-
-		log.Debug("before getting the user plan details")
-		err = d.LoadUserPlanDetails(ctx, userPlan)
-		if err != nil {
-			return err
-		}
-		log.Debug("affter getting the user plan details")
-
-		return nil
-	})
+	userPlan, err := a.GetUserSummary(ctx, username)
 	if err != nil {
 		sendError(ctx, response, err)
 		return
 	}
 
-	response.UserPlan = userPlan.ToQMSUserPlan()
+	response.UserPlan = userPlan
 	if err = a.client.Respond(ctx, reply, response); err != nil {
 		log.Error(err)
 	}

--- a/app/userPlans.go
+++ b/app/userPlans.go
@@ -5,5 +5,5 @@ import (
 )
 
 func (a *App) GetUserPlanHandler(subject, reply string, request *qms.RequestByUsername) {
-	a.GetUserSummary(subject, reply, request)
+	a.GetUserSummaryHandler(subject, reply, request)
 }

--- a/db/db.go
+++ b/db/db.go
@@ -37,7 +37,7 @@ func (d *Database) LogSQL(statement SQLStatement) {
 	if d.logSQL {
 		sql, args, err := statement.ToSQL()
 		if err != nil {
-			log.Error("unable to generate the SQL: %s", err)
+			log.Errorf("unable to generate the SQL: %s", err)
 			return
 		}
 		log.Infof("%s %v", sql, args)

--- a/db/db.go
+++ b/db/db.go
@@ -37,7 +37,8 @@ func (d *Database) LogSQL(statement SQLStatement) {
 	if d.logSQL {
 		sql, args, err := statement.ToSQL()
 		if err != nil {
-			log.Error("unable to ")
+			log.Error("unable to generate the SQL: %s", err)
+			return
 		}
 		log.Infof("%s %v", sql, args)
 	}

--- a/db/db.go
+++ b/db/db.go
@@ -14,6 +14,7 @@ type Database struct {
 	db     *sqlx.DB
 	fullDB *goqu.Database
 	goquDB GoquDatabase
+	debug  bool
 }
 
 func New(dbconn *sqlx.DB) *Database {
@@ -22,7 +23,7 @@ func New(dbconn *sqlx.DB) *Database {
 		db:     dbconn, // Used when a method needs direct access to sqlx for struct scanning.
 		fullDB: goquDB, // Used when a method needs to use a method not defined in the GoquDatabase interface.
 		goquDB: goquDB, // Used when a method needs to optionally support being run inside a transaction.
-
+		debug:  false,  // Set to true to log SQL statements. TODO: implement for all statements.
 	}
 }
 

--- a/db/db.go
+++ b/db/db.go
@@ -14,7 +14,7 @@ type Database struct {
 	db     *sqlx.DB
 	fullDB *goqu.Database
 	goquDB GoquDatabase
-	debug  bool
+	logSQL bool
 }
 
 func New(dbconn *sqlx.DB) *Database {
@@ -23,7 +23,23 @@ func New(dbconn *sqlx.DB) *Database {
 		db:     dbconn, // Used when a method needs direct access to sqlx for struct scanning.
 		fullDB: goquDB, // Used when a method needs to use a method not defined in the GoquDatabase interface.
 		goquDB: goquDB, // Used when a method needs to optionally support being run inside a transaction.
-		debug:  false,  // Set to true to log SQL statements. TODO: implement for all statements.
+		logSQL: false,  // Set to true to log SQL statements. TODO: implement for all statements.
+	}
+}
+
+// EnableSQLLogging enables SQL logging for the database instance.
+func (d *Database) EnableSQLLogging() {
+	d.logSQL = true
+}
+
+// LogSQL logs an SQL statement that is being executed if debugging is enabled.
+func (d *Database) LogSQL(statement SQLStatement) {
+	if d.logSQL {
+		sql, args, err := statement.ToSQL()
+		if err != nil {
+			log.Error("unable to ")
+		}
+		log.Infof("%s %v", sql, args)
 	}
 }
 

--- a/db/plans.go
+++ b/db/plans.go
@@ -2,87 +2,151 @@ package db
 
 import (
 	"context"
+	"fmt"
 
 	t "github.com/cyverse-de/subscriptions/db/tables"
 	"github.com/doug-martin/goqu/v9"
+	"github.com/pkg/errors"
 )
 
-func planDS(db GoquDatabase) *goqu.SelectDataset {
-	return db.From(t.Plans).
-		Select(
-			t.Plans.Col("id"),
-			t.Plans.Col("name"),
-			t.Plans.Col("description"),
+// func planDS(db GoquDatabase) *goqu.SelectDataset {
+// 	return db.From(t.Plans).
+// 		Select(
+// 			t.Plans.Col("id"),
+// 			t.Plans.Col("name"),
+// 			t.Plans.Col("description"),
 
-			t.PQD.Col("id").As(goqu.C("plan_quota_defaults.id")),
-			t.PQD.Col("plan_id").As(goqu.C("plan_quota_defaults.plan_id")),
-			t.PQD.Col("quota_value").As(goqu.C("plan_quota_defaults.quota_value")),
-			t.PQD.Col("resource_type_id").As(goqu.C("plan_quota_defaults.resource_type_id")),
+// 			t.PQD.Col("id").As(goqu.C("plan_quota_defaults.id")),
+// 			t.PQD.Col("plan_id").As(goqu.C("plan_quota_defaults.plan_id")),
+// 			t.PQD.Col("quota_value").As(goqu.C("plan_quota_defaults.quota_value")),
+// 			t.PQD.Col("resource_type_id").As(goqu.C("plan_quota_defaults.resource_type_id")),
+
+// 			t.RT.Col("id").As(goqu.C("resource_types.id")),
+// 			t.RT.Col("name").As(goqu.C("resource_types.name")),
+// 			t.RT.Col("unit").As(goqu.C("resource_types.unit")),
+// 		).
+// 		Join(t.PQD, goqu.On(t.PQD.Col("plan_id").Eq(t.Plans.Col("id")))).
+// 		Join(t.RT, goqu.On(t.PQD.Col("resource_type_id").Eq(t.RT.Col("id"))))
+// }
+
+func planDetailsDS(db GoquDatabase, planID string) *goqu.SelectDataset {
+	return db.From(t.PQD).
+		Select(
+			t.PQD.Col("id"),
+			t.PQD.Col("plan_id"),
+			t.PQD.Col("quota_value"),
 
 			t.RT.Col("id").As(goqu.C("resource_types.id")),
 			t.RT.Col("name").As(goqu.C("resource_types.name")),
 			t.RT.Col("unit").As(goqu.C("resource_types.unit")),
 		).
-		Join(t.PQD, goqu.On(t.PQD.Col("plan_id").Eq(t.Plans.Col("id")))).
-		Join(t.RT, goqu.On(t.PQD.Col("resource_type_id").Eq(t.RT.Col("id"))))
+		Join(t.RT, goqu.On(t.PQD.Col("resource_type_id").Eq(t.RT.Col("id")))).
+		Where(t.PQD.Col("plan_id").Eq(planID))
+}
+
+func (d *Database) getPlanList(ctx context.Context, opts ...QueryOption) ([]Plan, error) {
+	wrapMsg := "unable to list the plans"
+	_, db := d.querySettings(opts...)
+
+	// Build the query.
+	query := db.From(t.Plans)
+	d.LogSQL(query)
+
+	// Execute the query and scan the results.
+	var plans []Plan
+	if err := query.ScanStructsContext(ctx, &plans); err != nil {
+		return nil, errors.Wrap(err, wrapMsg)
+	}
+
+	return plans, nil
+}
+
+func (d *Database) loadPlanDetails(ctx context.Context, plan *Plan, opts ...QueryOption) error {
+	wrapMsg := fmt.Sprintf("unable to load details for plan ID %s", plan.ID)
+	_, db := d.querySettings(opts...)
+
+	// Build the query.
+	query := planDetailsDS(db, plan.ID)
+	d.LogSQL(query)
+
+	// Execute the query and scan the results.
+	err := query.ScanStructsContext(ctx, &plan.QuotaDefaults)
+	if err != nil {
+		return errors.Wrap(err, wrapMsg)
+	}
+	return nil
 }
 
 func (d *Database) ListPlans(ctx context.Context, opts ...QueryOption) ([]Plan, error) {
-	_, db := d.querySettings(opts...)
-
-	query := planDS(db).Executor()
-
-	var plans []Plan
-
-	if err := query.ScanStructsContext(ctx, &plans); err != nil {
+	// Get the list of plans.
+	plans, err := d.getPlanList(ctx, opts...)
+	if err != nil {
 		return nil, err
+	}
+
+	// Load the details for each plan in the list.
+	for i := range plans {
+		err = d.loadPlanDetails(ctx, &plans[i], opts...)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return plans, nil
 }
 
 func (d *Database) GetPlanByID(ctx context.Context, planID string, opts ...QueryOption) (*Plan, error) {
-	var (
-		err  error
-		db   GoquDatabase
-		plan Plan
-	)
+	wrapMsg := fmt.Sprintf("unable to look up plan %s", planID)
+	_, db := d.querySettings(opts...)
 
-	_, db = d.querySettings(opts...)
+	// Build the query.
+	query := db.From(t.Plans).Where(t.Plans.Col("id").Eq(planID))
+	d.LogSQL(query)
 
-	query := planDS(db).
-		Where(
-			t.Plans.Col("id").Eq(planID),
-		).
-		Executor()
-
-	if err = query.ScanStructsContext(ctx, &plan); err != nil {
-		return nil, err
+	// Execute the query and scan the results.
+	var plan Plan
+	found, err := query.Executor().ScanStructContext(ctx, &plan)
+	if err != nil {
+		return nil, errors.Wrap(err, wrapMsg)
+	}
+	if !found {
+		return nil, nil
 	}
 
-	return &plan, err
+	// Load the plan details.
+	err = d.loadPlanDetails(ctx, &plan, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, wrapMsg)
+	}
+
+	return &plan, nil
 }
 
 func (d *Database) GetPlanByName(ctx context.Context, name string, opts ...QueryOption) (*Plan, error) {
-	var (
-		err  error
-		db   GoquDatabase
-		plan Plan
-	)
+	wrapMsg := fmt.Sprintf("unable to look up plan %s", name)
+	_, db := d.querySettings(opts...)
 
-	_, db = d.querySettings(opts...)
+	// Build the query.
+	query := db.From(t.Plans).Where(t.Plans.Col("name").Eq(name))
+	d.LogSQL(query)
 
-	query := planDS(db).
-		Where(
-			t.Plans.Col("name").Eq(name),
-		).
-		Executor()
-
-	if err = query.ScanStructsContext(ctx, &plan); err != nil {
-		return nil, err
+	// Execute the query and scan the results.
+	var plan Plan
+	found, err := query.Executor().ScanStructContext(ctx, &plan)
+	if err != nil {
+		return nil, errors.Wrap(err, wrapMsg)
+	}
+	if !found {
+		return nil, nil
 	}
 
-	return &plan, err
+	// Load the plan details.
+	err = d.loadPlanDetails(ctx, &plan, opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, wrapMsg)
+	}
+
+	return &plan, nil
 }
 
 func (d *Database) AddPlan(ctx context.Context, plan *Plan, opts ...QueryOption) (string, error) {

--- a/db/plans.go
+++ b/db/plans.go
@@ -9,26 +9,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-// func planDS(db GoquDatabase) *goqu.SelectDataset {
-// 	return db.From(t.Plans).
-// 		Select(
-// 			t.Plans.Col("id"),
-// 			t.Plans.Col("name"),
-// 			t.Plans.Col("description"),
-
-// 			t.PQD.Col("id").As(goqu.C("plan_quota_defaults.id")),
-// 			t.PQD.Col("plan_id").As(goqu.C("plan_quota_defaults.plan_id")),
-// 			t.PQD.Col("quota_value").As(goqu.C("plan_quota_defaults.quota_value")),
-// 			t.PQD.Col("resource_type_id").As(goqu.C("plan_quota_defaults.resource_type_id")),
-
-// 			t.RT.Col("id").As(goqu.C("resource_types.id")),
-// 			t.RT.Col("name").As(goqu.C("resource_types.name")),
-// 			t.RT.Col("unit").As(goqu.C("resource_types.unit")),
-// 		).
-// 		Join(t.PQD, goqu.On(t.PQD.Col("plan_id").Eq(t.Plans.Col("id")))).
-// 		Join(t.RT, goqu.On(t.PQD.Col("resource_type_id").Eq(t.RT.Col("id"))))
-// }
-
 func planDetailsDS(db GoquDatabase, planID string) *goqu.SelectDataset {
 	return db.From(t.PQD).
 		Select(

--- a/db/types.go
+++ b/db/types.go
@@ -33,6 +33,10 @@ type GoquDatabase interface {
 	Update(table interface{}) *goqu.UpdateDataset
 }
 
+type SQLStatement interface {
+	ToSQL() (sql string, params []interface{}, err error)
+}
+
 var CurrentTimestamp = goqu.L("CURRENT_TIMESTAMP")
 
 var UpdateOperationNames = []string{"ADD", "SET"}

--- a/db/types.go
+++ b/db/types.go
@@ -44,6 +44,8 @@ var UpdateOperationNames = []string{"ADD", "SET"}
 const UsagesTrackedMetric = "usages"
 const QuotasTrackedMetric = "quotas"
 
+const DefaultPlanName = "Basic"
+
 type UpdateOperation struct {
 	ID   string `db:"id" goqu:"defaultifempty"`
 	Name string `db:"name"`
@@ -105,7 +107,7 @@ type Plan struct {
 	ID            string             `db:"id" goqu:"defaultifempty"`
 	Name          string             `db:"name"`
 	Description   string             `db:"description"`
-	QuotaDefaults []PlanQuotaDefault `db:"plan_quota_defaults"`
+	QuotaDefaults []PlanQuotaDefault `db:"-"`
 }
 
 type PlanQuotaDefault struct {

--- a/db/userplans.go
+++ b/db/userplans.go
@@ -107,7 +107,7 @@ func (d *Database) SetActiveUserPlan(ctx context.Context, userID, planID string,
 	d.LogSQL(query)
 
 	var userPlanID string
-	if err := query.Executor().ScanValsContext(ctx, &userPlanID); err != nil {
+	if _, err := query.Executor().ScanValContext(ctx, &userPlanID); err != nil {
 		return "", err
 	}
 
@@ -121,7 +121,7 @@ func (d *Database) SetActiveUserPlan(ctx context.Context, userID, planID string,
 			"last_modified_by",
 		).
 		FromQuery(
-			db.From(t.PQD).
+			goqu.From(t.PQD).
 				Select(
 					t.PQD.Col("resource_type_id"),
 					goqu.V(userPlanID).As("user_plan_id"),

--- a/db/userplans.go
+++ b/db/userplans.go
@@ -42,8 +42,12 @@ func (d *Database) GetUserPlanByID(ctx context.Context, userPlanID string, opts 
 	d.LogSQL(ds)
 
 	var result UserPlan
-	if err := ds.Executor().ScanStructsContext(ctx, &result); err != nil {
+	found, err := ds.Executor().ScanStructContext(ctx, &result)
+	if err != nil {
 		return nil, err
+	}
+	if !found {
+		return nil, nil
 	}
 
 	return &result, nil
@@ -263,7 +267,7 @@ func (d *Database) UserPlanQuotas(ctx context.Context, userPlanID string, opts .
 			t.RT.Col("name").As(goqu.C("resource_types.name")),
 			t.RT.Col("unit").As(goqu.C("resource_types.unit")),
 		).
-		Join(t.RT, goqu.On(goqu.I("t.Quotas.resource_type_id").Eq(goqu.I("resource_types.id")))).
+		Join(t.RT, goqu.On(goqu.I("quotas.resource_type_id").Eq(goqu.I("resource_types.id")))).
 		Where(t.Quotas.Col("user_plan_id").Eq(userPlanID))
 	d.LogSQL(quotasQuery)
 

--- a/db/users.go
+++ b/db/users.go
@@ -130,12 +130,7 @@ func (d *Database) EnsureUser(ctx context.Context, username string, opts ...Quer
 				Where(goqu.Ex{"username": username}))
 
 	// Log the SQL statement if we're debugging database calls.
-	if d.debug {
-		sql, params, err := statement.ToSQL()
-		if err == nil {
-			log.Warnf("EnsureUser: %s %v", sql, params)
-		}
-	}
+	d.LogSQL(statement)
 
 	// Execute the statement and fetch the result.
 	found, err := statement.Executor().ScanStructContext(ctx, &result)

--- a/db/users.go
+++ b/db/users.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/doug-martin/goqu/v9"
+	"github.com/pkg/errors"
 )
 
 // GetUserID returns a user's UUID associated with their username.
@@ -100,4 +101,50 @@ func (d *Database) AddUser(ctx context.Context, username string, opts ...QueryOp
 	}
 
 	return id, nil
+}
+
+// EnsureUser ensures that a user with the given username exists in the database then returns the user information.
+// This function accepts a variable number of QueryOptions, but only WithTX is currently supported.
+func (d *Database) EnsureUser(ctx context.Context, username string, opts ...QueryOption) (*User, error) {
+	var (
+		wrapMsg string = "unable to ensure that the user exists in the database"
+		err     error
+		db      GoquDatabase
+		result  User
+	)
+
+	// Prepare to execute the statement.
+	_, db = d.querySettings(opts...)
+
+	// Build the statement.
+	usersT := goqu.T("users")
+	statement := db.From("ins").
+		With("ins",
+			db.Insert(usersT).
+				Returning("id", "username").
+				Rows(goqu.Record{"username": username}).
+				OnConflict(goqu.DoNothing())).
+		UnionAll(
+			db.From(usersT).
+				Select("id", "username").
+				Where(goqu.Ex{"username": username}))
+
+	// Log the SQL statement if we're debugging database calls.
+	if d.debug {
+		sql, params, err := statement.ToSQL()
+		if err == nil {
+			log.Warnf("EnsureUser: %s %v", sql, params)
+		}
+	}
+
+	// Execute the statement and fetch the result.
+	found, err := statement.Executor().ScanStructContext(ctx, &result)
+	if err != nil {
+		return nil, errors.Wrap(err, wrapMsg)
+	}
+	if !found {
+		return nil, nil
+	}
+
+	return &result, nil
 }

--- a/main.go
+++ b/main.go
@@ -166,7 +166,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err = natsClient.Subscribe(qmssubs.UserSummary, a.GetUserSummary); err != nil {
+	if err = natsClient.Subscribe(qmssubs.UserSummary, a.GetUserSummaryHandler); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
Prior to this change, the user summary handler would not create a new subscription if the user didn't already have an active subscription. This caused an error for new users because nothing triggered the system to create a basic subscription for users without an active subscription. This PR adds that capability and fixes some errors. Some refactoring was done, primarily in order to facilitate development testing.