### PR TITLE
CORE-1839: Rename user_plans table to subscriptions

### DIFF
--- a/app/quotas.go
+++ b/app/quotas.go
@@ -27,22 +27,22 @@ func (a *App) AddQuotaHandler(subject, reply string, request *qms.AddQuotaReques
 	ctx, span := pbinit.InitQMSAddQuotaRequest(request, subject)
 	defer span.End()
 
-	userPlanID := request.Quota.UserPlanId
+	subscriptionID := request.Quota.SubscriptionId
 
 	d := db.New(a.db)
 
-	_, update, err := d.GetCurrentQuota(ctx, request.Quota.ResourceType.Uuid, userPlanID)
+	_, update, err := d.GetCurrentQuota(ctx, request.Quota.ResourceType.Uuid, subscriptionID)
 	if err != nil {
 		sendError(ctx, response, err)
 		return
 	}
 
-	if err = d.UpsertQuota(ctx, update, float64(request.Quota.Quota), request.Quota.ResourceType.Uuid, userPlanID); err != nil {
+	if err = d.UpsertQuota(ctx, update, float64(request.Quota.Quota), request.Quota.ResourceType.Uuid, subscriptionID); err != nil {
 		sendError(ctx, response, err)
 		return
 	}
 
-	value, _, err := d.GetCurrentQuota(ctx, request.Quota.ResourceType.Uuid, userPlanID)
+	value, _, err := d.GetCurrentQuota(ctx, request.Quota.ResourceType.Uuid, subscriptionID)
 	if err != nil {
 		sendError(ctx, response, err)
 		return
@@ -50,7 +50,7 @@ func (a *App) AddQuotaHandler(subject, reply string, request *qms.AddQuotaReques
 
 	response.Quota.Quota = float32(value)
 	response.Quota.ResourceType = request.Quota.ResourceType
-	response.Quota.UserPlanId = userPlanID
+	response.Quota.SubscriptionId = subscriptionID
 
 	if err = a.client.Respond(ctx, reply, response); err != nil {
 		log.Error(err)

--- a/app/usages.go
+++ b/app/usages.go
@@ -37,13 +37,13 @@ func (a *App) GetUsagesHandler(subject, reply string, request *qms.GetUsages) {
 
 	d := db.New(a.db)
 
-	userPlan, err := d.GetActiveUserPlan(ctx, username)
+	subscription, err := d.GetActiveSubscription(ctx, username)
 	if err != nil {
 		sendError(ctx, response, err)
 		return
 	}
 
-	usages, err := d.UserPlanUsages(ctx, userPlan.ID)
+	usages, err := d.SubscriptionUsages(ctx, subscription.ID)
 	if err != nil {
 		sendError(ctx, response, err)
 		return
@@ -51,9 +51,9 @@ func (a *App) GetUsagesHandler(subject, reply string, request *qms.GetUsages) {
 
 	for _, usage := range usages {
 		response.Usages = append(response.Usages, &qms.Usage{
-			Uuid:       usage.ID,
-			Usage:      usage.Usage,
-			UserPlanId: userPlan.ID,
+			Uuid:           usage.ID,
+			Usage:          usage.Usage,
+			SubscriptionId: subscription.ID,
 			ResourceType: &qms.ResourceType{
 				Uuid: usage.ResourceType.ID,
 				Name: usage.ResourceType.Name,
@@ -103,7 +103,7 @@ func (a *App) AddUsageHandler(subject, reply string, request *qms.AddUsage) {
 
 	d := db.New(a.db)
 
-	userPlan, err := d.GetActiveUserPlan(ctx, username)
+	subscription, err := d.GetActiveSubscription(ctx, username)
 	if err != nil {
 		sendError(ctx, response, err)
 		return
@@ -122,8 +122,8 @@ func (a *App) AddUsageHandler(subject, reply string, request *qms.AddUsage) {
 	}
 
 	usage = db.Usage{
-		Usage:      request.UsageValue,
-		UserPlanID: userPlan.ID,
+		Usage:          request.UsageValue,
+		SubscriptionID: subscription.ID,
 		ResourceType: db.ResourceType{
 			ID:   resourceID,
 			Name: request.ResourceName,

--- a/app/userPlans.go
+++ b/app/userPlans.go
@@ -4,6 +4,6 @@ import (
 	"github.com/cyverse-de/p/go/qms"
 )
 
-func (a *App) GetUserPlanHandler(subject, reply string, request *qms.RequestByUsername) {
+func (a *App) GetSubscriptionHandler(subject, reply string, request *qms.RequestByUsername) {
 	a.GetUserSummaryHandler(subject, reply, request)
 }

--- a/app/users.go
+++ b/app/users.go
@@ -91,7 +91,7 @@ func (a *App) AddUserHandler(subject, reply string, request *qms.AddUserRequest)
 
 	if !hasPlan {
 		// If the user isn't on a plan, put them on one.
-		if _, err = d.SetActiveUserPlan(ctx, userID, plan.ID, db.WithTX(tx)); err != nil {
+		if _, err = d.SetActiveSubscription(ctx, userID, plan.ID, db.WithTX(tx)); err != nil {
 			sendError(ctx, response, err)
 			return
 		}
@@ -106,7 +106,7 @@ func (a *App) AddUserHandler(subject, reply string, request *qms.AddUserRequest)
 
 		// If the user isn't on the plan contained in the request, put them on it.
 		if !onPlan {
-			if _, err = d.SetActiveUserPlan(ctx, userID, plan.ID, db.WithTX(tx)); err != nil {
+			if _, err = d.SetActiveSubscription(ctx, userID, plan.ID, db.WithTX(tx)); err != nil {
 				sendError(ctx, response, err)
 				return
 			}

--- a/db/overages.go
+++ b/db/overages.go
@@ -18,9 +18,9 @@ func (d *Database) GetUserOverages(ctx context.Context, username string, opts ..
 
 	_, db = d.querySettings(opts...)
 
-	query := db.From(t.UserPlans).
+	query := db.From(t.Subscriptions).
 		Select(
-			t.UserPlans.Col("id").As("user_plan_id"),
+			t.Subscriptions.Col("id").As("subscription_id"),
 
 			t.Users.Col("id").As(goqu.C("users.id")),
 			t.Users.Col("username").As(goqu.C("users.username")),
@@ -36,18 +36,18 @@ func (d *Database) GetUserOverages(ctx context.Context, username string, opts ..
 			t.Quotas.Col("quota").As("quota_value"),
 			t.Usages.Col("usage").As("usage_value"),
 		).
-		Join(t.Users, goqu.On(t.UserPlans.Col("user_id").Eq(t.Users.Col("id")))).
-		Join(t.Plans, goqu.On(t.UserPlans.Col("plan_id").Eq(t.Plans.Col("id")))).
-		Join(t.Quotas, goqu.On(t.UserPlans.Col("id").Eq(t.Quotas.Col("user_plan_id")))).
-		Join(t.Usages, goqu.On(t.UserPlans.Col("id").Eq(t.Usages.Col("user_plan_id")))).
+		Join(t.Users, goqu.On(t.Subscriptions.Col("user_id").Eq(t.Users.Col("id")))).
+		Join(t.Plans, goqu.On(t.Subscriptions.Col("plan_id").Eq(t.Plans.Col("id")))).
+		Join(t.Quotas, goqu.On(t.Subscriptions.Col("id").Eq(t.Quotas.Col("subscription_id")))).
+		Join(t.Usages, goqu.On(t.Subscriptions.Col("id").Eq(t.Usages.Col("subscription_id")))).
 		Join(t.ResourceTypes, goqu.On(t.Usages.Col("resource_type_id").Eq(t.ResourceTypes.Col("id")))).
 		Where(goqu.And(
 			t.Users.Col("username").Eq(username),
 			goqu.Or(
-				CurrentTimestamp.Between(goqu.Range(t.UserPlans.Col("effective_start_date"), t.UserPlans.Col("effective_end_date"))),
+				CurrentTimestamp.Between(goqu.Range(t.Subscriptions.Col("effective_start_date"), t.Subscriptions.Col("effective_end_date"))),
 				goqu.And(
-					CurrentTimestamp.Gt(t.UserPlans.Col("effective_start_date")),
-					t.UserPlans.Col("effective_end_date").IsNull(),
+					CurrentTimestamp.Gt(t.Subscriptions.Col("effective_start_date")),
+					t.Subscriptions.Col("effective_end_date").IsNull(),
 				),
 			),
 			t.Usages.Col("resource_type_id").Eq(t.Quotas.Col("resource_type_id")),

--- a/db/quotas.go
+++ b/db/quotas.go
@@ -12,7 +12,7 @@ import (
 // was found and returned and is false when the actual quota was not found and
 // the default value was returned. Accepts a variable number of QuotaOptions,
 // but only WithTX is currently supported.
-func (d *Database) GetCurrentQuota(ctx context.Context, resourceTypeID, userPlanID string, opts ...QueryOption) (float64, bool, error) {
+func (d *Database) GetCurrentQuota(ctx context.Context, resourceTypeID, subscriptionID string, opts ...QueryOption) (float64, bool, error) {
 	var (
 		err        error
 		db         GoquDatabase
@@ -25,7 +25,7 @@ func (d *Database) GetCurrentQuota(ctx context.Context, resourceTypeID, userPlan
 		Select(goqu.C("quota")).
 		Where(goqu.And(
 			goqu.I("resource_type_id").Eq(resourceTypeID),
-			goqu.I("user_plan_id").Eq(userPlanID),
+			goqu.I("subscription_id").Eq(subscriptionID),
 		)).
 		Limit(1).
 		Executor()
@@ -45,7 +45,7 @@ func (d *Database) GetCurrentQuota(ctx context.Context, resourceTypeID, userPlan
 // UpsertQuota inserts or updates a quota into the database for the given
 // resource type and user plan. Accepts a variable number of QueryOptions,
 // though only WithTX is currently supported.
-func (d *Database) UpsertQuota(ctx context.Context, update bool, value float64, resourceTypeID, userPlanID string, opts ...QueryOption) error {
+func (d *Database) UpsertQuota(ctx context.Context, update bool, value float64, resourceTypeID, subscriptionID string, opts ...QueryOption) error {
 	var (
 		err error
 		db  GoquDatabase
@@ -56,7 +56,7 @@ func (d *Database) UpsertQuota(ctx context.Context, update bool, value float64, 
 	updateRecord := goqu.Record{
 		"quota":            value,
 		"resource_type_id": resourceTypeID,
-		"user_plan_id":     userPlanID,
+		"subscription_id":  subscriptionID,
 		"created_by":       "de",
 		"last_modified_by": "de",
 	}
@@ -68,7 +68,7 @@ func (d *Database) UpsertQuota(ctx context.Context, update bool, value float64, 
 		upsertE = db.Update("quotas").Set(updateRecord).Where(
 			goqu.And(
 				goqu.I("resource_type_id").Eq(resourceTypeID),
-				goqu.I("user_plan_id").Eq(userPlanID),
+				goqu.I("subscription_id").Eq(subscriptionID),
 			),
 		).Executor()
 	}

--- a/db/tables/tables.go
+++ b/db/tables/tables.go
@@ -6,7 +6,7 @@ var (
 	UpdateOperations  = goqu.T("update_operations")
 	UOps              = UpdateOperations
 	Users             = goqu.T("users")
-	UserPlans         = goqu.T("user_plans")
+	Subscriptions     = goqu.T("subscriptions")
 	Plans             = goqu.T("plans")
 	PlanQuotaDefaults = goqu.T("plan_quota_defaults")
 	PQD               = PlanQuotaDefaults

--- a/db/types.go
+++ b/db/types.go
@@ -108,7 +108,7 @@ type Update struct {
 	UpdateOperation UpdateOperation `db:"update_operations"`
 }
 
-type UserPlan struct {
+type Subscription struct {
 	ID                 string    `db:"id" goqu:"defaultifempty"`
 	EffectiveStartDate time.Time `db:"effective_start_date"`
 	EffectiveEndDate   time.Time `db:"effective_end_date"`
@@ -122,7 +122,7 @@ type UserPlan struct {
 	LastModifiedAt     string    `db:"last_modified_at" goqu:"defaultifempty"`
 }
 
-func (up UserPlan) ToQMSUserPlan() *qms.UserPlan {
+func (up Subscription) ToQMSSubscription() *qms.Subscription {
 	// Convert the list of quotas.
 	quotas := make([]*qms.Quota, len(up.Quotas))
 	for i, quota := range up.Quotas {
@@ -135,7 +135,7 @@ func (up UserPlan) ToQMSUserPlan() *qms.UserPlan {
 		usages[i] = usage.ToQMSUsage()
 	}
 
-	return &qms.UserPlan{
+	return &qms.Subscription{
 		Uuid:               up.ID,
 		EffectiveStartDate: timestamppb.New(up.EffectiveStartDate),
 		EffectiveEndDate:   timestamppb.New(up.EffectiveEndDate),
@@ -186,7 +186,7 @@ func (pqd PlanQuotaDefault) ToQMSQuotaDefault() *qms.QuotaDefault {
 type Usage struct {
 	ID             string       `db:"id" goqu:"defaultifempty"`
 	Usage          float64      `db:"usage"`
-	UserPlanID     string       `db:"user_plan_id"`
+	SubscriptionID string       `db:"subscription_id"`
 	ResourceType   ResourceType `db:"resource_types"`
 	CreatedBy      string       `db:"created_by"`
 	CreatedAt      time.Time    `db:"created_at"`
@@ -210,7 +210,7 @@ type Quota struct {
 	ID             string       `db:"id" goqu:"defaultifempty"`
 	Quota          float64      `db:"quota"`
 	ResourceType   ResourceType `db:"resource_types"`
-	UserPlan       UserPlan     `db:"user_plans"`
+	Subscription   Subscription `db:"subscriptions"`
 	CreatedBy      string       `db:"created_by"`
 	CreatedAt      time.Time    `db:"created_at"`
 	LastModifiedBy string       `db:"last_modified_by"`
@@ -230,10 +230,10 @@ func (q Quota) ToQMSQuota() *qms.Quota {
 }
 
 type Overage struct {
-	UserPlanID   string       `db:"user_plan_id"`
-	User         User         `db:"users"`
-	Plan         Plan         `db:"plans"`
-	ResourceType ResourceType `db:"resource_types"`
-	QuotaValue   float64      `db:"quota_value"`
-	UsageValue   float64      `db:"usage_value"`
+	SubscriptionID string       `db:"subscription_id"`
+	User           User         `db:"users"`
+	Plan           Plan         `db:"plans"`
+	ResourceType   ResourceType `db:"resource_types"`
+	QuotaValue     float64      `db:"quota_value"`
+	UsageValue     float64      `db:"usage_value"`
 }

--- a/db/updates.go
+++ b/db/updates.go
@@ -134,14 +134,14 @@ func (d *Database) ProcessUpdateForUsage(ctx context.Context, update *Update) er
 
 	if err = tx.Wrap(func() error {
 		log.Debug("before getting active user plan")
-		userPlan, err := d.GetActiveUserPlan(ctx, update.User.Username, WithTX(tx))
+		subscription, err := d.GetActiveSubscription(ctx, update.User.Username, WithTX(tx))
 		if err != nil {
 			return err
 		}
-		log.Debugf("after getting active user plan %s", userPlan.ID)
+		log.Debugf("after getting active user plan %s", subscription.ID)
 
 		log.Debug("getting current usage")
-		usageValue, usageFound, err := d.GetCurrentUsage(ctx, update.ResourceType.ID, userPlan.ID, WithTX(tx))
+		usageValue, usageFound, err := d.GetCurrentUsage(ctx, update.ResourceType.ID, subscription.ID, WithTX(tx))
 		if err != nil {
 			return err
 		}
@@ -159,7 +159,7 @@ func (d *Database) ProcessUpdateForUsage(ctx context.Context, update *Update) er
 		log.Debugf("new usage value is %f", usageValue)
 
 		log.Debug("upserting new usage value")
-		if err = d.UpsertUsage(ctx, usageFound, usageValue, update.ResourceType.ID, userPlan.ID, WithTX(tx)); err != nil {
+		if err = d.UpsertUsage(ctx, usageFound, usageValue, update.ResourceType.ID, subscription.ID, WithTX(tx)); err != nil {
 			return err
 		}
 		log.Debug("done upserting new value")
@@ -187,12 +187,12 @@ func (d *Database) ProcessUpdateForQuota(ctx context.Context, update *Update, op
 	}
 
 	if err = tx.Wrap(func() error {
-		userPlan, err := d.GetActiveUserPlan(ctx, update.User.Username, WithTX(tx))
+		subscription, err := d.GetActiveSubscription(ctx, update.User.Username, WithTX(tx))
 		if err != nil {
 			return err
 		}
 
-		quotaValue, quotaFound, err := d.GetCurrentQuota(ctx, update.ResourceType.ID, userPlan.ID, WithTX(tx))
+		quotaValue, quotaFound, err := d.GetCurrentQuota(ctx, update.ResourceType.ID, subscription.ID, WithTX(tx))
 		if err != nil {
 			return err
 		}
@@ -211,7 +211,7 @@ func (d *Database) ProcessUpdateForQuota(ctx context.Context, update *Update, op
 			quotaFound,
 			quotaValue,
 			update.ResourceType.ID,
-			userPlan.ID,
+			subscription.ID,
 			WithTX(tx),
 		); err != nil {
 			return err

--- a/go.mod
+++ b/go.mod
@@ -7,10 +7,10 @@ require (
 	github.com/cyverse-de/go-mod/gotelnats v0.0.11
 	github.com/cyverse-de/go-mod/logging v0.0.2
 	github.com/cyverse-de/go-mod/otelutils v0.0.3
-	github.com/cyverse-de/go-mod/pbinit v0.0.15
+	github.com/cyverse-de/go-mod/pbinit v0.1.0
 	github.com/cyverse-de/go-mod/protobufjson v0.0.3
-	github.com/cyverse-de/go-mod/subjects v0.0.6
-	github.com/cyverse-de/p/go/qms v0.0.19
+	github.com/cyverse-de/go-mod/subjects v0.1.0
+	github.com/cyverse-de/p/go/qms v0.1.0
 	github.com/cyverse-de/p/go/svcerror v0.0.7
 	github.com/doug-martin/goqu/v9 v9.18.0
 	github.com/jmoiron/sqlx v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -32,6 +32,8 @@ github.com/cyverse-de/go-mod/pbinit v0.0.14 h1:WCnXWt7GjwizwNlX+Frjml3FU2xDT33SW
 github.com/cyverse-de/go-mod/pbinit v0.0.14/go.mod h1:mclUGhzWh/BzLsFwbpfgpaDIQMWUAbmYE+IzYOLy/Jg=
 github.com/cyverse-de/go-mod/pbinit v0.0.15 h1:AVy9Te4DS/vzyV0WkrnQ1VfWkFtGXLlrDhce841nMLk=
 github.com/cyverse-de/go-mod/pbinit v0.0.15/go.mod h1:olSiblycPLTy4IFu3hnmHjZG0CkB2Uk02ldXfv3wea4=
+github.com/cyverse-de/go-mod/pbinit v0.1.0 h1:XtP5JECr5bi4i0xIR4W2UQOJJGQAfS2LNI9rebHKI98=
+github.com/cyverse-de/go-mod/pbinit v0.1.0/go.mod h1:9JN/oBPmtdxepTHUbYsjEWUxdfXDDnuY1dbSH9zO6es=
 github.com/cyverse-de/go-mod/protobufjson v0.0.3 h1:XTIZejY7EUbpF6ZdhRhiFX9PGYDkGGmPP760cDswGWM=
 github.com/cyverse-de/go-mod/protobufjson v0.0.3/go.mod h1:p/ASemjpl2GEFYb3Tt7N8RozViwonsK0fOm0LxYeCt8=
 github.com/cyverse-de/go-mod/subjects v0.0.4 h1:GXYKZSigpt0TgsdFLkpXP6aKvtqLSPLCjHJ3QzLEbKI=
@@ -40,6 +42,8 @@ github.com/cyverse-de/go-mod/subjects v0.0.5 h1:vHxHq4zm6UepTkBbPBCOsD4MeG1Rq1Og
 github.com/cyverse-de/go-mod/subjects v0.0.5/go.mod h1:x8P+TNVSXvehkWMAmrg1RQHc5CCGafqtTKUn0hklkFA=
 github.com/cyverse-de/go-mod/subjects v0.0.6 h1:gQ3Rb2Tu7/kQMRCI1iSTyDB6yTHCUiZP8nDm3JyIJ4E=
 github.com/cyverse-de/go-mod/subjects v0.0.6/go.mod h1:x8P+TNVSXvehkWMAmrg1RQHc5CCGafqtTKUn0hklkFA=
+github.com/cyverse-de/go-mod/subjects v0.1.0 h1:ba9v19djad2a+p+TmQiDsl668p2XLt5fhNd24R2rpwU=
+github.com/cyverse-de/go-mod/subjects v0.1.0/go.mod h1:x8P+TNVSXvehkWMAmrg1RQHc5CCGafqtTKUn0hklkFA=
 github.com/cyverse-de/p/go/analysis v0.0.13 h1:65hbQSnj1sDJcUnDJwMto/ncBxO6PSsWMFuIcyeQZV0=
 github.com/cyverse-de/p/go/analysis v0.0.13/go.mod h1:zI19t8ygFWsXKmcIb6cLAgiPRR+fHHT716hFNPbGDOc=
 github.com/cyverse-de/p/go/header v0.0.1 h1:YgI0DLIOvL6m0LF22tFUk3OHLtW5NCuNiaGqwkxv64s=
@@ -60,6 +64,8 @@ github.com/cyverse-de/p/go/qms v0.0.17 h1:OA6m21ciPah3MEcBGplqREUh0cnjnYV0Pr6e/8
 github.com/cyverse-de/p/go/qms v0.0.17/go.mod h1:2zWzMlzjUeGWErAuovBkfD39rPFrqsbKOjl8tUy36I4=
 github.com/cyverse-de/p/go/qms v0.0.19 h1:CkYr/M3vgOiZbCD1zhXPnAZn+911Btqbl1YPKXoIU3Y=
 github.com/cyverse-de/p/go/qms v0.0.19/go.mod h1:2zWzMlzjUeGWErAuovBkfD39rPFrqsbKOjl8tUy36I4=
+github.com/cyverse-de/p/go/qms v0.1.0 h1:nH9fdPx09tFqfNp8NKG+tCRcUYdNYKl1UO9xyul6/qk=
+github.com/cyverse-de/p/go/qms v0.1.0/go.mod h1:lDNWgFPsT0sg3fqHHEE2yhERNsfFueYJiprxtoOnp4c=
 github.com/cyverse-de/p/go/svcerror v0.0.5 h1:WbUcU4VjbNU0agfrHJOCy9orAY72WJWo92b1vR3+3sw=
 github.com/cyverse-de/p/go/svcerror v0.0.5/go.mod h1:WCGIrhW0KXtSu86YhjU/JXG8LrZs5wJPBCH4wvnFYcQ=
 github.com/cyverse-de/p/go/svcerror v0.0.7 h1:PScx8ctSBtnkER6ypgWsuxe8p3/jgfh6t/Dy5J9tg48=

--- a/main.go
+++ b/main.go
@@ -174,7 +174,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	if err = natsClient.Subscribe(qmssubs.GetUserPlan, a.GetUserPlanHandler); err != nil {
+	if err = natsClient.Subscribe(qmssubs.GetSubscription, a.GetSubscriptionHandler); err != nil {
 		log.Fatal(err)
 	}
 


### PR DESCRIPTION
This PR is part of the effort to rename the `user_plans` table in the QMS database to `subscriptions`. This includes changing all type names, references to `user_plans` in the SQL, and all NATS subjects containing references to user_plans or UserPlans.

