### PR TITLE
CORE-1840: paid subscription flag

### DIFF
--- a/app/plans.go
+++ b/app/plans.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/cyverse-de/go-mod/pbinit"
 	"github.com/cyverse-de/p/go/qms"
@@ -168,5 +169,15 @@ func (a *App) GetPlanHandler(subject, reply string, request *qms.PlanRequest) {
 }
 
 func (a *App) UpsertQuotaDefaultsHandler(subject, reply string, request *qms.AddPlanQuotaDefaultRequest) {
-
+	sendError := func(ctx context.Context, response *qms.QuotaDefaultResponse, err error) {
+		log.Error(err)
+		response.Error = errors.NatsError(ctx, err)
+		if err = a.client.Respond(ctx, reply, response); err != nil {
+			log.Error(err)
+		}
+	}
+	response := pbinit.NewQuotaDefaultResponse()
+	ctx, span := pbinit.InitQMSAddPlanQuotaDefaultRequest(request, subject)
+	defer span.End()
+	sendError(ctx, response, fmt.Errorf("not implemented"))
 }

--- a/app/quotas.go
+++ b/app/quotas.go
@@ -48,9 +48,11 @@ func (a *App) AddQuotaHandler(subject, reply string, request *qms.AddQuotaReques
 		return
 	}
 
-	response.Quota.Quota = float32(value)
-	response.Quota.ResourceType = request.Quota.ResourceType
-	response.Quota.SubscriptionId = subscriptionID
+	response.Quota = &qms.Quota{
+		Quota:          float32(value),
+		ResourceType:   request.Quota.ResourceType,
+		SubscriptionId: subscriptionID,
+	}
 
 	if err = a.client.Respond(ctx, reply, response); err != nil {
 		log.Error(err)

--- a/app/summary.go
+++ b/app/summary.go
@@ -50,7 +50,7 @@ func (a *App) GetUserSummary(ctx context.Context, username string) (*qms.Subscri
 				return err
 			}
 
-			subscriptionID, err := d.SetActiveSubscription(ctx, user.ID, plan.ID, db.WithTX(tx))
+			subscriptionID, err := d.SetActiveSubscription(ctx, user.ID, plan.ID, false, db.WithTX(tx))
 			if err != nil {
 				log.Errorf("unable to subscribe the user to the default plan: %s", err)
 				return err

--- a/app/summary.go
+++ b/app/summary.go
@@ -116,6 +116,8 @@ func (a *App) GetUserSummaryHandler(subject, reply string, request *qms.RequestB
 		return
 	}
 
+	log.Warnf("Reply: %s", reply)
+
 	response.Subscription = subscription
 	if err = a.client.Respond(ctx, reply, response); err != nil {
 		log.Error(err)

--- a/app/users.go
+++ b/app/users.go
@@ -91,7 +91,7 @@ func (a *App) AddUserHandler(subject, reply string, request *qms.AddUserRequest)
 
 	if !hasPlan {
 		// If the user isn't on a plan, put them on one.
-		if _, err = d.SetActiveSubscription(ctx, userID, plan.ID, db.WithTX(tx)); err != nil {
+		if _, err = d.SetActiveSubscription(ctx, userID, plan.ID, true, db.WithTX(tx)); err != nil {
 			sendError(ctx, response, err)
 			return
 		}
@@ -106,7 +106,7 @@ func (a *App) AddUserHandler(subject, reply string, request *qms.AddUserRequest)
 
 		// If the user isn't on the plan contained in the request, put them on it.
 		if !onPlan {
-			if _, err = d.SetActiveSubscription(ctx, userID, plan.ID, db.WithTX(tx)); err != nil {
+			if _, err = d.SetActiveSubscription(ctx, userID, plan.ID, true, db.WithTX(tx)); err != nil {
 				sendError(ctx, response, err)
 				return
 			}

--- a/app/users.go
+++ b/app/users.go
@@ -49,8 +49,9 @@ func (a *App) AddUserHandler(subject, reply string, request *qms.AddUserRequest)
 		_ = tx.Rollback()
 	}()
 
-	// get the plan named in the request
+	// extract information about the subscription from the request
 	planName := request.PlanName
+	paid := request.Paid
 
 	plan, err := d.GetPlanByName(ctx, planName, db.WithTX(tx))
 	if err != nil {
@@ -91,7 +92,7 @@ func (a *App) AddUserHandler(subject, reply string, request *qms.AddUserRequest)
 
 	if !hasPlan {
 		// If the user isn't on a plan, put them on one.
-		if _, err = d.SetActiveSubscription(ctx, userID, plan.ID, true, db.WithTX(tx)); err != nil {
+		if _, err = d.SetActiveSubscription(ctx, userID, plan.ID, paid, db.WithTX(tx)); err != nil {
 			sendError(ctx, response, err)
 			return
 		}
@@ -106,7 +107,7 @@ func (a *App) AddUserHandler(subject, reply string, request *qms.AddUserRequest)
 
 		// If the user isn't on the plan contained in the request, put them on it.
 		if !onPlan {
-			if _, err = d.SetActiveSubscription(ctx, userID, plan.ID, true, db.WithTX(tx)); err != nil {
+			if _, err = d.SetActiveSubscription(ctx, userID, plan.ID, paid, db.WithTX(tx)); err != nil {
 				sendError(ctx, response, err)
 				return
 			}

--- a/db/plans.go
+++ b/db/plans.go
@@ -142,8 +142,8 @@ func (d *Database) AddPlan(ctx context.Context, plan *Plan, opts ...QueryOption)
 		Executor()
 
 	var newPlanID string
-	if err := ds.ScanValsContext(ctx, newPlanID); err != nil {
-		return "", err
+	if _, err := ds.ScanValContext(ctx, &newPlanID); err != nil {
+		return "", errors.Wrap(err, "unable to add the new plan")
 	}
 
 	for _, pqd := range plan.QuotaDefaults {
@@ -156,8 +156,9 @@ func (d *Database) AddPlan(ctx context.Context, plan *Plan, opts ...QueryOption)
 				},
 			).Executor()
 
-		if _, err := newDS.ExecContext(ctx); err != nil {
-			return "", err
+		if _, err := newDS.ExecContext(ctx); err !=
+			nil {
+			return "", errors.Wrap(err, "unable to add plan quota defaults")
 		}
 	}
 

--- a/db/types.go
+++ b/db/types.go
@@ -120,6 +120,7 @@ type Subscription struct {
 	CreatedAt          time.Time `db:"created_at" goqu:"defaultifempty"`
 	LastModifiedBy     string    `db:"last_modified_by"`
 	LastModifiedAt     string    `db:"last_modified_at" goqu:"defaultifempty"`
+	Paid               bool      `db:"paid" goqu:"defaultifempty"`
 }
 
 func (up Subscription) ToQMSSubscription() *qms.Subscription {
@@ -143,7 +144,7 @@ func (up Subscription) ToQMSSubscription() *qms.Subscription {
 		Plan:               up.Plan.ToQMSPlan(),
 		Quotas:             quotas,
 		Usages:             usages,
-		Paid:               true,
+		Paid:               up.Paid,
 	}
 }
 

--- a/db/types.go
+++ b/db/types.go
@@ -143,6 +143,7 @@ func (up Subscription) ToQMSSubscription() *qms.Subscription {
 		Plan:               up.Plan.ToQMSPlan(),
 		Quotas:             quotas,
 		Usages:             usages,
+		Paid:               true,
 	}
 }
 

--- a/db/userplans.go
+++ b/db/userplans.go
@@ -20,6 +20,7 @@ func subscriptionDS(db GoquDatabase) *goqu.SelectDataset {
 			t.Subscriptions.Col("created_at").As("created_at"),
 			t.Subscriptions.Col("last_modified_by").As("last_modified_by"),
 			t.Subscriptions.Col("last_modified_at").As("last_modified_at"),
+			t.Subscriptions.Col("paid").As("paid"),
 
 			t.Users.Col("id").As(goqu.C("users.id")),
 			t.Users.Col("username").As(goqu.C("users.username")),
@@ -90,7 +91,9 @@ func (d *Database) GetActiveSubscription(ctx context.Context, username string, o
 	return &result, nil
 }
 
-func (d *Database) SetActiveSubscription(ctx context.Context, userID, planID string, opts ...QueryOption) (string, error) {
+func (d *Database) SetActiveSubscription(
+	ctx context.Context, userID, planID string, paid bool, opts ...QueryOption,
+) (string, error) {
 	_, db := d.querySettings(opts...)
 
 	n := time.Now()
@@ -105,6 +108,7 @@ func (d *Database) SetActiveSubscription(ctx context.Context, userID, planID str
 				"plan_id":              planID,
 				"created_by":           "de",
 				"last_modified_by":     "de",
+				"paid":                 paid,
 			},
 		).
 		Returning(t.Subscriptions.Col("id"))

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cyverse-de/go-mod/pbinit v0.1.0
 	github.com/cyverse-de/go-mod/protobufjson v0.0.3
 	github.com/cyverse-de/go-mod/subjects v0.1.0
-	github.com/cyverse-de/p/go/qms v0.1.0
+	github.com/cyverse-de/p/go/qms v0.1.2
 	github.com/cyverse-de/p/go/svcerror v0.0.7
 	github.com/doug-martin/goqu/v9 v9.18.0
 	github.com/jmoiron/sqlx v1.3.5

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/cyverse-de/go-mod/pbinit v0.1.0
 	github.com/cyverse-de/go-mod/protobufjson v0.0.3
 	github.com/cyverse-de/go-mod/subjects v0.1.0
-	github.com/cyverse-de/p/go/qms v0.1.2
+	github.com/cyverse-de/p/go/qms v0.1.3
 	github.com/cyverse-de/p/go/svcerror v0.0.7
 	github.com/doug-martin/goqu/v9 v9.18.0
 	github.com/jmoiron/sqlx v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/cyverse-de/p/go/qms v0.0.19 h1:CkYr/M3vgOiZbCD1zhXPnAZn+911Btqbl1YPKX
 github.com/cyverse-de/p/go/qms v0.0.19/go.mod h1:2zWzMlzjUeGWErAuovBkfD39rPFrqsbKOjl8tUy36I4=
 github.com/cyverse-de/p/go/qms v0.1.0 h1:nH9fdPx09tFqfNp8NKG+tCRcUYdNYKl1UO9xyul6/qk=
 github.com/cyverse-de/p/go/qms v0.1.0/go.mod h1:lDNWgFPsT0sg3fqHHEE2yhERNsfFueYJiprxtoOnp4c=
+github.com/cyverse-de/p/go/qms v0.1.2 h1:8dYW9Rvix/QiJdlGtF0tHfJwwVF1/BhzYBFo3+2zD70=
+github.com/cyverse-de/p/go/qms v0.1.2/go.mod h1:lDNWgFPsT0sg3fqHHEE2yhERNsfFueYJiprxtoOnp4c=
 github.com/cyverse-de/p/go/svcerror v0.0.5 h1:WbUcU4VjbNU0agfrHJOCy9orAY72WJWo92b1vR3+3sw=
 github.com/cyverse-de/p/go/svcerror v0.0.5/go.mod h1:WCGIrhW0KXtSu86YhjU/JXG8LrZs5wJPBCH4wvnFYcQ=
 github.com/cyverse-de/p/go/svcerror v0.0.7 h1:PScx8ctSBtnkER6ypgWsuxe8p3/jgfh6t/Dy5J9tg48=

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/cyverse-de/p/go/qms v0.1.0 h1:nH9fdPx09tFqfNp8NKG+tCRcUYdNYKl1UO9xyul
 github.com/cyverse-de/p/go/qms v0.1.0/go.mod h1:lDNWgFPsT0sg3fqHHEE2yhERNsfFueYJiprxtoOnp4c=
 github.com/cyverse-de/p/go/qms v0.1.2 h1:8dYW9Rvix/QiJdlGtF0tHfJwwVF1/BhzYBFo3+2zD70=
 github.com/cyverse-de/p/go/qms v0.1.2/go.mod h1:lDNWgFPsT0sg3fqHHEE2yhERNsfFueYJiprxtoOnp4c=
+github.com/cyverse-de/p/go/qms v0.1.3 h1:IcdQ/CBGCtTgapv2NmfcZuTKI+q6VI5V0E4ibVxGtVs=
+github.com/cyverse-de/p/go/qms v0.1.3/go.mod h1:lDNWgFPsT0sg3fqHHEE2yhERNsfFueYJiprxtoOnp4c=
 github.com/cyverse-de/p/go/svcerror v0.0.5 h1:WbUcU4VjbNU0agfrHJOCy9orAY72WJWo92b1vR3+3sw=
 github.com/cyverse-de/p/go/svcerror v0.0.5/go.mod h1:WCGIrhW0KXtSu86YhjU/JXG8LrZs5wJPBCH4wvnFYcQ=
 github.com/cyverse-de/p/go/svcerror v0.0.7 h1:PScx8ctSBtnkER6ypgWsuxe8p3/jgfh6t/Dy5J9tg48=

--- a/main.go
+++ b/main.go
@@ -47,8 +47,10 @@ func main() {
 		dotEnvPath     = flag.String("dotenv-path", cfg.DefaultDotEnvPath, "Path to the dotenv file")
 		tlsCert        = flag.String("tlscert", gotelnats.DefaultTLSCertPath, "Path to the NATS TLS cert file")
 		tlsKey         = flag.String("tlskey", gotelnats.DefaultTLSKeyPath, "Path to the NATS TLS key file")
+		noTLS          = flag.Bool("no-tls", false, "Used to disable TLS for the connection to NATS")
 		caCert         = flag.String("tlsca", gotelnats.DefaultTLSCAPath, "Path to the NATS TLS CA file")
 		credsPath      = flag.String("creds", gotelnats.DefaultCredsPath, "Path to the NATS creds file")
+		noCreds        = flag.Bool("no-creds", false, "Used to disable client credentials for NATS")
 		maxReconnects  = flag.Int("max-reconnects", gotelnats.DefaultMaxReconnects, "Maximum number of reconnection attempts to NATS")
 		reconnectWait  = flag.Int("reconnect-wait", gotelnats.DefaultReconnectWait, "Seconds to wait between reconnection attempts to NATS")
 		natsSubject    = flag.String("subject", "cyverse.qms.>", "NATS subject to subscribe to")
@@ -112,9 +114,11 @@ func main() {
 	natsSettings := natscl.ConnectionSettings{
 		ClusterURLS:   natsCluster,
 		CredsPath:     *credsPath,
+		CredsEnabled:  !*noCreds,
 		TLSCACertPath: *caCert,
 		TLSCertPath:   *tlsCert,
 		TLSKeyPath:    *tlsKey,
+		TLSEnabled:    !*noTLS,
 		MaxReconnects: *maxReconnects,
 		ReconnectWait: *reconnectWait,
 	}

--- a/natscl/natscl.go
+++ b/natscl/natscl.go
@@ -85,7 +85,7 @@ func (s *ConnectionSettings) toConnectOptions() []nats.Option {
 func NewConnection(settings *ConnectionSettings) (*nats.EncodedConn, error) {
 	log := log.WithFields(logrus.Fields{"context": "new nats conn"})
 
-	log.Debug("NATS Settings: %+v", settings)
+	log.Infof("establishing the NATS connection: %s", settings.ClusterURLS)
 
 	nc, err := nats.Connect(settings.ClusterURLS, settings.toConnectOptions()...)
 	if err != nil {

--- a/natscl/natscl.go
+++ b/natscl/natscl.go
@@ -2,6 +2,7 @@ package natscl
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
 
@@ -16,36 +17,77 @@ var log = logging.Log.WithFields(logrus.Fields{"package": "natscl"})
 type ConnectionSettings struct {
 	ClusterURLS   string
 	CredsPath     string
+	CredsEnabled  bool
 	TLSCACertPath string
 	TLSCertPath   string
 	TLSKeyPath    string
+	TLSEnabled    bool
 	MaxReconnects int
 	ReconnectWait int
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return false
+	}
+	if err != nil {
+		log.Panicf("unable to check for the existence of %s", path)
+	}
+	return true
+}
+
+func (s *ConnectionSettings) toConnectOptions() []nats.Option {
+	options := make([]nats.Option, 0)
+
+	// Add the credentials if a path is specified and it exists.
+	if s.CredsEnabled && s.CredsPath != "" && fileExists(s.CredsPath) {
+		options = append(options, nats.UserCredentials(s.CredsPath))
+	}
+
+	// Add the TLS settings if we're supposed to.
+	if s.TLSEnabled {
+		options = append(options, nats.RootCAs(s.TLSCACertPath))
+		options = append(options, nats.ClientCert(s.TLSCertPath, s.TLSKeyPath))
+	}
+
+	// Add the rest of the options.
+	options = append(options, nats.RetryOnFailedConnect(true))
+	options = append(options, nats.MaxReconnects(s.MaxReconnects))
+	options = append(options, nats.ReconnectWait(time.Duration(s.ReconnectWait)*time.Second))
+
+	// A handler funciton to log error messages when the NATS connection is dropped.
+	options = append(options, nats.DisconnectErrHandler(
+		func(nc *nats.Conn, err error) {
+			if err != nil {
+				log.Errorf("disconnected from nats: %s", err.Error())
+			}
+		},
+	))
+
+	// A handler function to log an informational message when the NATS connection is restored.
+	options = append(options, nats.ReconnectHandler(
+		func(nc *nats.Conn) {
+			log.Infof("reconnected to %s", nc.ConnectedUrl())
+		},
+	))
+
+	// A handler function to log an informational message when the NATS connection is closed.
+	options = append(options, nats.ClosedHandler(
+		func(nc *nats.Conn) {
+			log.Errorf("connection closed: %s", nc.LastError().Error())
+		},
+	))
+
+	return options
 }
 
 func NewConnection(settings *ConnectionSettings) (*nats.EncodedConn, error) {
 	log := log.WithFields(logrus.Fields{"context": "new nats conn"})
 
-	nc, err := nats.Connect(
-		settings.ClusterURLS,
-		nats.UserCredentials(settings.CredsPath),
-		nats.RootCAs(settings.TLSCACertPath),
-		nats.ClientCert(settings.TLSCertPath, settings.TLSKeyPath),
-		nats.RetryOnFailedConnect(true),
-		nats.MaxReconnects(settings.MaxReconnects),
-		nats.ReconnectWait(time.Duration(settings.ReconnectWait)*time.Second),
-		nats.DisconnectErrHandler(func(nc *nats.Conn, err error) {
-			if err != nil {
-				log.Errorf("disconnected from nats: %s", err.Error())
-			}
-		}),
-		nats.ReconnectHandler(func(nc *nats.Conn) {
-			log.Infof("reconnected to %s", nc.ConnectedUrl())
-		}),
-		nats.ClosedHandler(func(nc *nats.Conn) {
-			log.Errorf("connection closed: %s", nc.LastError().Error())
-		}),
-	)
+	log.Debug("NATS Settings: %+v", settings)
+
+	nc, err := nats.Connect(settings.ClusterURLS, settings.toConnectOptions()...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The primary purpose of this change is to add support for the paid subscription flag, not including subscription add-ons. Support for subscription add-ons will be added in a subsequent PR. The following changes are included in this PR:

* command-line options were added to allow non-TLS and unauthenticated NATS connections
* the paid subscription flag was added to the summary response body
* a segmentation fault in `AddQuotaHandler` was fixed
* fixed a database error that was occurring when new plans are created
* added a database transaction to `AddPlanHandler` to avoid partial updates if an error occurs in the first SQL statment
* updated `UpsertQuotaDefaultsHandler` to return an error indicating that it's not implemented yet
* updated `GetUserSummary` to mark subscriptions that are added by default as not paid
* updated `AddUserHandler` to accept a paid subscription flag for newly created subscriptions