### PR TITLE
use EnsureUser when processing updates so the user ID isn't an empty string

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -180,11 +180,12 @@ func (a *App) AddUserUpdateHandler(subject, reply string, request *qms.AddUpdate
 	// Get the userID if it's not provided
 	if request.Update.User.Uuid == "" {
 		log.Infof("getting user ID for %s", username)
-		userID, err = d.GetUserID(ctx, username)
+		user, err := d.EnsureUser(ctx, username)
 		if err != nil {
 			sendError(ctx, response, err)
 			return
 		}
+		userID = user.ID
 		log.Infof("user ID for %s is %s", username, userID)
 	} else {
 		userID = request.Update.User.Uuid

--- a/db/updates.go
+++ b/db/updates.go
@@ -141,7 +141,7 @@ func (d *Database) ProcessUpdateForUsage(ctx context.Context, update *Update) er
 		log.Debugf("after getting active user plan %s", subscription.ID)
 
 		// create a subscription if there isn't one
-		if subscription == nil || subscription.ID == "" {
+		if subscription.ID == "" {
 			user, err := d.EnsureUser(ctx, update.User.Username, WithTX(tx))
 			if err != nil {
 				log.Errorf("unable to ensure that the user exists in the database: %s", err)


### PR DESCRIPTION
Unsure if I need to make sure the user is set up with the default subscription or stuff like that as well, but this seems like the first step at least.