### PR TITLE
User suffix is unused in NATS code, remove

### DIFF
--- a/main.go
+++ b/main.go
@@ -95,7 +95,7 @@ func main() {
 		log.Fatal(errors.Wrap(err, "Can't parse database.uri in the config file"))
 	}
 
-	userSuffix := config.String("users.domain")
+	userSuffix := strings.Trim(config.String("users.domain"), "@")
 	if userSuffix == "" {
 		log.Fatal("users.domain must be set in the configuration file")
 	}
@@ -139,7 +139,7 @@ func main() {
 	log.Infof("NATS queue is %s", *natsQueue)
 	log.Infof("--report-overages is %t", *reportOverages)
 
-	natsClient := natscl.NewClient(natsConn, userSuffix, serviceName)
+	natsClient := natscl.NewClient(natsConn, serviceName)
 
 	a := app.New(natsClient, dbconn, userSuffix)
 

--- a/natscl/natscl.go
+++ b/natscl/natscl.go
@@ -103,14 +103,12 @@ func NewConnection(settings *ConnectionSettings) (*nats.EncodedConn, error) {
 type Client struct {
 	conn          *nats.EncodedConn
 	subscriptions []*nats.Subscription
-	userSuffix    string
 	queueSuffix   string
 }
 
-func NewClient(conn *nats.EncodedConn, userSuffix, queueSuffix string) *Client {
+func NewClient(conn *nats.EncodedConn, queueSuffix string) *Client {
 	return &Client{
 		conn:          conn,
-		userSuffix:    userSuffix,
 		queueSuffix:   queueSuffix,
 		subscriptions: make([]*nats.Subscription, 0),
 	}


### PR DESCRIPTION
The user suffix is used in the app code, but was already written in a way that doesn't need changing, so I didn't touch that part.