### PR TITLE
CORE-2016: allow for addon rates to be inserted when a UUID is specified

### DIFF
--- a/db/types.go
+++ b/db/types.go
@@ -655,6 +655,18 @@ func (r *AddonRate) ToQMSType() *qms.AddonRate {
 	}
 }
 
+func (r *AddonRate) ToRec() goqu.Record {
+	var rec = map[string]any{
+		"addon_id":       r.AddonID,
+		"effective_date": r.EffectiveDate,
+		"rate":           r.Rate,
+	}
+	if r.ID != "" {
+		rec["id"] = r.ID
+	}
+	return goqu.Record(rec)
+}
+
 func (r *AddonRate) Validate() error {
 
 	// The rate can't be negative.


### PR DESCRIPTION
This fixes a problem where addon rates weren't being updated correctly when an addon was updated.