### PR TITLE
CORE-2093: finish adding support for the `consumable` flag for resource types.

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build Commands
+
+```bash
+# Build the main subscriptions service
+make
+
+# Build both subscriptions and dev-test programs
+make all
+
+# Clean build artifacts
+make clean
+
+# Download Go dependencies
+go mod download
+
+# Run golangci-lint (requires golangci-lint to be installed)
+golangci-lint run
+```
+
+## Architecture Overview
+
+This is a NATS-centric microservice implementing subscription management functionality, designed to replace the legacy
+QMS service. The service handles user subscriptions, quotas, usage tracking, and resource management through NATS
+messaging.
+
+### Core Components
+
+1. **main.go** - Entry point that:
+   - Configures NATS connection with TLS/credentials support
+   - Sets up PostgreSQL database connection with OpenTelemetry instrumentation
+   - Registers NATS message handlers for various QMS subjects
+   - Starts HTTP server for health checks and metrics
+
+2. **app/** - Application layer containing business logic handlers:
+   - `app.go` - Main application struct and initialization
+   - `users.go` - User management handlers
+   - `plans.go` - Subscription plan management
+   - `quotas.go` - Quota management and validation
+   - `usages.go` - Resource usage tracking
+   - `addons.go` - Subscription addon management
+   - `overages.go` - Overage checking and reporting
+   - `summary.go` - User subscription summary generation
+   - `userPlans.go` - User-plan associations
+
+3. **db/** - Database layer with PostgreSQL operations:
+   - `db.go` - Database connection and transaction management
+   - `types.go` - Database model types and structures
+   - `tables/` - SQL table definitions using goqu query builder
+   - Resource-specific files matching app/ structure
+
+4. **natscl/** - NATS client wrapper for connection management
+
+### NATS Message Handlers
+
+The service subscribes to these NATS subjects (defined in go-mod/subjects/qms):
+- User updates and usage tracking
+- Subscription and plan management
+- Quota operations
+- Addon management
+- Overage checking
+
+All handlers follow request/response pattern with protobuf message serialization.
+
+## Configuration
+
+The service uses a layered configuration approach:
+1. Configuration file: `/etc/cyverse/de/configs/service.yml` (or specify with `--config`)
+2. Dotenv file: `/etc/cyverse/de/env/service.env` (or specify with `--dotenv-path`)
+3. Environment variables with `QMS_` prefix
+
+Key configuration settings:
+- `QMS_DATABASE_URI` - PostgreSQL connection string
+- `QMS_NATS_CLUSTER` - NATS cluster URLs
+- `QMS_USERNAME_SUFFIX` - User domain suffix (e.g., @iplantcollaborative.org)
+
+## Local Development
+
+For local development without TLS/credentials:
+```bash
+# Create local dotenv file with configuration
+echo 'QMS_USERNAME_SUFFIX=@iplantcollaborative.org
+QMS_DATABASE_URI=postgresql://de@localhost/qms?sslmode=disable
+QMS_NATS_CLUSTER=nats://localhost:4222' > dotenv
+
+# Run the service
+./subscriptions --no-tls --no-creds --dotenv-path dotenv
+```
+
+## Testing with NATS
+
+```bash
+# Subscribe to responses
+nats sub 'foo.bar'
+
+# Send a request (example: get user summary)
+nats pub --reply=foo.bar cyverse.qms.user.summary.get '{"username":"sarahr"}'
+```
+
+## Dependencies
+
+- NATS for messaging
+- PostgreSQL for data persistence
+- goqu for SQL query building
+- OpenTelemetry for observability
+- Protocol Buffers for message serialization

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,38 @@
-FROM golang:1.24 AS build-root
+# Build stage
+FROM golang:1.24-bullseye AS builder
 
-WORKDIR /go/src/github.com/cyverse-de/subscriptions
+WORKDIR /build
+
+# Copy go mod files first for better layer caching during rebuilds
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy source code
 COPY . .
 
+# Build the binary with size optimizations (-w removes DWARF debug info, -s removes symbol table)
 ENV CGO_ENABLED=0
 ENV GOOS=linux
 ENV GOARCH=amd64
 
-RUN go build --buildvcs=false .
-RUN go clean -cache -modcache
-RUN cp ./subscriptions /bin/subscriptions
+RUN go build -ldflags="-w -s" --buildvcs=false -o subscriptions .
+
+# Runtime stage - small debian-based image
+FROM debian:stable-slim
+
+# Install ca-certificates for HTTPS connections, then clean up apt cache
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Create non-root user for security
+RUN useradd -r -u 1000 -m -s /bin/false appuser
+
+# Copy only the binary from builder
+COPY --from=builder /build/subscriptions /bin/subscriptions
+
+# Switch to non-root user
+USER appuser
 
 ENTRYPOINT ["subscriptions"]
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,0 @@
-#!groovy
-
-stage ('Trigger Build') {
-	build job: 'Build-Tag-Push-Deploy-QA', wait: true, parameters: [
-		[$class: 'StringParameterValue', name: 'PROJECT', value: 'subscriptions']
-	]
-}

--- a/app/app.go
+++ b/app/app.go
@@ -171,6 +171,7 @@ func (a *App) getUserUpdates(ctx context.Context, request *qms.UpdateListRequest
 				Uuid: mu.ResourceType.ID,
 				Name: mu.ResourceType.Name,
 				Unit: mu.ResourceType.Unit,
+				Consumable: mu.ResourceType.Consumable,
 			},
 			Operation: &qms.UpdateOperation{
 				Uuid: mu.UpdateOperation.ID,
@@ -302,6 +303,7 @@ func (a *App) addUserUpdate(ctx context.Context, request *qms.AddUpdateRequest) 
 				ID:   resourceTypeID,
 				Name: request.Update.ResourceType.Name,
 				Unit: request.Update.ResourceType.Unit,
+				Consumable: request.Update.ResourceType.Consumable,
 			},
 			User: db.User{
 				ID:       userID,
@@ -354,6 +356,7 @@ func (a *App) addUserUpdate(ctx context.Context, request *qms.AddUpdateRequest) 
 				Uuid: update.ResourceType.ID,
 				Name: update.ResourceType.Name,
 				Unit: update.ResourceType.Unit,
+				Consumable: update.ResourceType.Consumable,
 			},
 			EffectiveDate: timestamppb.New(update.EffectiveDate),
 			Operation: &qms.UpdateOperation{

--- a/app/app.go
+++ b/app/app.go
@@ -358,7 +358,7 @@ func (a *App) addUserUpdate(ctx context.Context, request *qms.AddUpdateRequest) 
 			return err
 		}
 		if recordedUpdate == nil {
-			return fmt.Errorf("unable to find the user upate after recording it: %s", update.ID)
+			return fmt.Errorf("unable to find the user update after recording it: %s", update.ID)
 		}
 		response.Update = &qms.Update{
 			Uuid:      recordedUpdate.ID,

--- a/app/plans.go
+++ b/app/plans.go
@@ -193,6 +193,7 @@ func (a *App) getPlan(ctx context.Context, request *qms.PlanRequest) *qms.PlanRe
 					Uuid: q.ResourceType.ID,
 					Name: q.ResourceType.Name,
 					Unit: q.ResourceType.Unit,
+					Consumable: q.ResourceType.Consumable,
 				},
 			})
 	}

--- a/app/quotas.go
+++ b/app/quotas.go
@@ -18,22 +18,45 @@ func (a *App) addQuota(ctx context.Context, request *qms.AddQuotaRequest) *qms.Q
 	subscriptionID := request.Quota.SubscriptionId
 
 	d := db.New(a.db)
-
-	if err = d.UpsertQuota(ctx, float64(request.Quota.Quota), request.Quota.ResourceType.Uuid, subscriptionID); err != nil {
-		response.Error = errors.NatsError(ctx, err)
-		return response
-	}
-
-	value, _, err := d.GetCurrentQuota(ctx, request.Quota.ResourceType.Uuid, subscriptionID)
+	tx, err := d.Begin()
 	if err != nil {
 		response.Error = errors.NatsError(ctx, err)
 		return response
 	}
+	err = tx.Wrap(func() error {
+		var err error
 
-	response.Quota = &qms.Quota{
-		Quota:          value,
-		ResourceType:   request.Quota.ResourceType,
-		SubscriptionId: subscriptionID,
+		// Store the quota in the database, overwriting the old quota if one exists for the resource type.
+		err = d.UpsertQuota(
+			ctx,
+			float64(request.Quota.Quota),
+			request.Quota.ResourceType.Uuid,
+			subscriptionID,
+			db.WithTX(tx),
+		)
+		if err != nil {
+			return err
+		}
+
+		// Load the quota from the database.
+		quota, err := d.LoadQuotaDetails(ctx,
+			request.Quota.ResourceType.Uuid,
+			subscriptionID,
+			db.WithTX(tx),
+		)
+		if err != nil {
+			return err
+		}
+		if quota == nil {
+			return errors.New("unable to load the quota after saving")
+		}
+
+		// Save the quota in the response.
+		response.Quota = quota.ToQMSQuota()
+		return nil
+	})
+	if err != nil {
+		response.Error = errors.NatsError(ctx, err)
 	}
 
 	return response

--- a/app/usages.go
+++ b/app/usages.go
@@ -45,6 +45,7 @@ func (a *App) getUsages(ctx context.Context, request *qms.GetUsages) *qms.UsageL
 				Uuid: usage.ResourceType.ID,
 				Name: usage.ResourceType.Name,
 				Unit: usage.ResourceType.Unit,
+				Consumable: usage.ResourceType.Consumable,
 			},
 			CreatedAt:      timestamppb.New(usage.CreatedAt),
 			CreatedBy:      usage.CreatedBy,

--- a/db/addons.go
+++ b/db/addons.go
@@ -61,6 +61,7 @@ func addonDS(db GoquDatabase) *goqu.SelectDataset {
 			t.ResourceTypes.Col("id").As(goqu.C("resource_types.id")),
 			t.ResourceTypes.Col("name").As(goqu.C("resource_types.name")),
 			t.ResourceTypes.Col("unit").As(goqu.C("resource_types.unit")),
+			t.ResourceTypes.Col("consumable").As(goqu.C("resource_types.consumable")),
 		).
 		Join(t.ResourceTypes, goqu.On(t.Addons.Col("resource_type_id").Eq(t.ResourceTypes.Col("id"))))
 }
@@ -107,6 +108,7 @@ func (d *Database) ListAddons(ctx context.Context, opts ...QueryOption) ([]Addon
 			t.ResourceTypes.Col("id").As(goqu.C("resource_types.id")),
 			t.ResourceTypes.Col("name").As(goqu.C("resource_types.name")),
 			t.ResourceTypes.Col("unit").As(goqu.C("resource_types.unit")),
+			t.ResourceTypes.Col("consumable").As(goqu.C("resource_types.consumable")),
 		).
 		Join(t.ResourceTypes, goqu.On(t.Addons.Col("resource_type_id").Eq(t.ResourceTypes.Col("id"))))
 	d.LogSQL(ds)
@@ -183,6 +185,7 @@ func (d *Database) ToggleAddonPaid(ctx context.Context, addonID string, opts ...
 			t.ResourceTypes.Col("id").As(goqu.C("resource_types.id")),
 			t.ResourceTypes.Col("name").As(goqu.C("resource_types.name")),
 			t.ResourceTypes.Col("unit").As(goqu.C("resource_types.unit")),
+			t.ResourceTypes.Col("consumable").As(goqu.C("resource_types.consumable")),
 		).
 		Join(t.ResourceTypes, goqu.On(t.Addons.Col("resource_type_id").Eq(t.ResourceTypes.Col("id")))).
 		Where(t.Addons.Col("id").Eq(addonID)).
@@ -336,6 +339,7 @@ func subAddonDS(db GoquDatabase) *goqu.SelectDataset {
 			t.ResourceTypes.Col("id").As(goqu.C("addons.resource_types.id")),
 			t.ResourceTypes.Col("name").As(goqu.C("addons.resource_types.name")),
 			t.ResourceTypes.Col("unit").As(goqu.C("addons.resource_types.unit")),
+			t.ResourceTypes.Col("consumable").As(goqu.C("addons.resource_types.consumable")),
 
 			t.SubscriptionAddons.Col("amount"),
 			t.SubscriptionAddons.Col("paid"),

--- a/db/overages.go
+++ b/db/overages.go
@@ -32,6 +32,7 @@ func (d *Database) GetUserOverages(ctx context.Context, username string, opts ..
 			t.ResourceTypes.Col("id").As(goqu.C("resource_types.id")),
 			t.ResourceTypes.Col("name").As(goqu.C("resource_types.name")),
 			t.ResourceTypes.Col("unit").As(goqu.C("resource_types.unit")),
+			t.ResourceTypes.Col("consumable").As(goqu.C("resource_types.consumable")),
 
 			t.Quotas.Col("quota").As("quota_value"),
 			t.Usages.Col("usage").As("usage_value"),

--- a/db/plans.go
+++ b/db/plans.go
@@ -20,6 +20,7 @@ func planQuotaDefaultsDS(db GoquDatabase, planID string) *goqu.SelectDataset {
 			t.RT.Col("id").As(goqu.C("resource_types.id")),
 			t.RT.Col("name").As(goqu.C("resource_types.name")),
 			t.RT.Col("unit").As(goqu.C("resource_types.unit")),
+			t.RT.Col("consumable").As(goqu.C("resource_types.consumable")),
 		).
 		Join(t.RT, goqu.On(t.PQD.Col("resource_type_id").Eq(t.RT.Col("id")))).
 		Where(t.PQD.Col("plan_id").Eq(planID)).

--- a/db/quotas.go
+++ b/db/quotas.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 
+	t "github.com/cyverse-de/subscriptions/db/tables"
 	"github.com/doug-martin/goqu/v9"
 )
 
@@ -39,6 +40,47 @@ func (d *Database) GetCurrentQuota(ctx context.Context, resourceTypeID, subscrip
 	}
 
 	return quotaValue, quotaFound, nil
+}
+
+// LoadQuotaDetails retrieves details about a quota from the database.
+func (d *Database) LoadQuotaDetails(
+	ctx context.Context,
+	resourceTypeID, subscriptionID string,
+	opts ...QueryOption,
+) (*Quota, error) {
+	_, db := d.querySettings(opts...)
+
+	// Build the query.
+	query := db.From(t.Quotas).
+		Select(
+			t.Quotas.Col("id").As("id"),
+			t.Quotas.Col("quota").As("quota"),
+			t.Quotas.Col("created_by").As("created_by"),
+			t.Quotas.Col("created_at").As("created_at"),
+			t.Quotas.Col("last_modified_by").As("last_modified_by"),
+			t.Quotas.Col("last_modified_at").As("last_modified_at"),
+			t.RT.Col("id").As(goqu.C("resource_types.id")),
+			t.RT.Col("name").As(goqu.C("resource_types.name")),
+			t.RT.Col("unit").As(goqu.C("resource_types.unit")),
+			t.RT.Col("consumable").As(goqu.C("resource_types.consumable")),
+		).
+		Join(t.RT, goqu.On(goqu.I("quotas.resource_type_id").Eq(goqu.I("resource_types.id")))).
+		Where(goqu.And(
+			goqu.I("resource_type_id").Eq(resourceTypeID),
+			goqu.I("subscription_id").Eq(subscriptionID),
+		))
+
+	// Execute the query.
+	var quota Quota
+	found, err := query.Executor().ScanStructContext(ctx, &quota)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+
+	return &quota, nil
 }
 
 // UpsertQuota inserts or updates a quota into the database for the given

--- a/db/types.go
+++ b/db/types.go
@@ -576,9 +576,10 @@ func (a *Addon) ToQMSType() *qms.Addon {
 		DefaultAmount: a.DefaultAmount,
 		DefaultPaid:   a.DefaultPaid,
 		ResourceType: &qms.ResourceType{
-			Uuid: a.ResourceType.ID,
-			Name: a.ResourceType.Name,
-			Unit: a.ResourceType.Unit,
+			Uuid:       a.ResourceType.ID,
+			Name:       a.ResourceType.Name,
+			Unit:       a.ResourceType.Unit,
+			Consumable: a.ResourceType.Consumable,
 		},
 		AddonRates: addonRates,
 	}

--- a/db/updates.go
+++ b/db/updates.go
@@ -37,6 +37,7 @@ func (d *Database) UserUpdates(ctx context.Context, username string, opts ...Que
 			t.RT.Col("id").As(goqu.C("resource_types.id")),
 			t.RT.Col("name").As(goqu.C("resource_types.name")),
 			t.RT.Col("unit").As(goqu.C("resource_types.unit")),
+			t.RT.Col("consumable").As(goqu.C("resource_types.consumable")),
 
 			t.UOps.Col("id").As(goqu.C("update_operations.id")),
 			t.UOps.Col("name").As(goqu.C("update_operations.name")),

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -25,6 +25,10 @@ var (
 	ErrSubscriptionAddonsExist = errors.New("subscription add-ons exist")
 )
 
+func New(s string) error {
+	return errors.New(s)
+}
+
 func HTTPStatusCode(err error) int {
 	switch err {
 	case ErrUserNotFound:


### PR DESCRIPTION
The purpose of this change is to ensure that the `consumable` flag is present for all resource types in most response bodies. The one notable exception is the handler for `cyverse.qms.user.plan.addons.delete`, which currently only returns the UUID of the subscription addon that was deleted. I left this alone because the resource type is nil in the response body also. We can fix it in a subsequent PR later if necessary.